### PR TITLE
Explicitly pass the current working directory to support .sops.yaml lookups

### DIFF
--- a/src/sops/sops.ts
+++ b/src/sops/sops.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as cp from "child_process";
+import * as path from 'path';
 
 interface SopsProps {
 
@@ -24,7 +25,8 @@ class Sops implements SopsProps {
 
     private exec(args: string[]): Promise<string> {
         return new Promise<string>((resolve, reject) => {
-            var child = cp.spawn("sops", args);
+            var cwd = path.dirname(vscode.window.activeTextEditor.document.fileName);
+            var child = cp.spawn("sops", args, {cwd});
             child.stdin.write(this.getContents());
             child.stdin.end();
             child.stdout.on("data", (data) => {


### PR DESCRIPTION
I think by default the code runs in the extension host directory instead of the current code location.
Without that fix an error is thrown that sops can't find the config file, despite that the config file was in the project root.